### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -11,7 +11,7 @@ paper:
     - name: Amy Gimma
     - name: CMMID COVID-19 working group
     - name: W. John Edmunds
-  reference: <https://cmmid.github.io/topics/covid19/control-measures/report/uk_scenario_modelling_preprint_2020_04_01.pdf>
+  reference: https://cmmid.github.io/topics/covid19/control-measures/report/uk_scenario_modelling_preprint_2020_04_01.pdf
 
 manifest:
   - file: fig-12week.pdf


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)

@nuest could you review and merge if you're okay with the changes. I do not have permission to merge.